### PR TITLE
Remove flycheck in favor of flymake via eglot

### DIFF
--- a/init.org
+++ b/init.org
@@ -538,24 +538,6 @@
        (add-hook 'erlang-mode-hook 'erlfmt-on-save-mode))
    #+END_SRC
 
-** Flycheck
-
-   #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package flycheck
-       :init
-       ;; (setq flycheck-ruby-executable (expand-file-name "~/.rbenv/shims/ruby"))
-       ;; (setq flycheck-ruby-rubocop-executable (expand-file-name "~/.rbenv/shims/rubocop"))
-       (setq flycheck-erlang-include-path '("../include"))
-       (setq flycheck-erlang-library-path '())
-       (add-hook 'ruby-mode-hook (lambda () (flycheck-disable-checker 'ruby-reek)))
-       :config
-       (setq-default flycheck-disabled-checkers
-                     (append flycheck-disabled-checkers
-                             '(javascript-jshint)
-                             '(json-jsonlist)))
-       (global-flycheck-mode))
-   #+END_SRC
-
 ** Gleam
 
    #+BEGIN_SRC emacs-lisp :tangle yes
@@ -722,11 +704,6 @@
        :custom
        (rust-format-on-save t)
        :defer t)
-   #+END_SRC
-
-   #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package flycheck-rust
-       :hook (rust-mode . flycheck-rust-setup))
    #+END_SRC
 
 ** Scala


### PR DESCRIPTION
## Summary

- Remove flycheck package and `global-flycheck-mode`
- Remove flycheck-rust package

## Why

Eglot uses flymake (built-in) for diagnostics, making flycheck redundant. This simplifies the config and avoids having two diagnostic systems running.

## Test plan

- [ ] Tangle and restart Emacs
- [ ] Open a Go/TypeScript file with errors
- [ ] Verify diagnostics appear (underlines, error messages in echo area)
- [ ] Run `M-x flymake-show-buffer-diagnostics` to see all issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)