### PR TITLE
Runtime performance optimizations

### DIFF
--- a/init.org
+++ b/init.org
@@ -57,6 +57,16 @@
      (straight-use-package 'use-package)
    #+END_SRC
 
+** Performance
+
+   Increase GC threshold and process output buffer size for better runtime
+   performance, especially with LSP.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (setq gc-cons-threshold (* 100 1024 1024))
+     (setq read-process-output-max (* 4 1024 1024))
+   #+END_SRC
+
    Run ~M-x straight-pull-all~ to update all packages, and then run ~M-x
    straight-freeze-versions~ to save the currently checked out revisions of all
    packages. The ~~/.emacs.d/straight/versions/default.el~ file, together with
@@ -462,8 +472,6 @@
      (use-package eglot
        :straight (:type built-in)
        :config
-       (setq gc-cons-threshold 100000000)
-       (setq read-process-output-max (* 1024 1024))
        (setq eglot-autoshutdown t)
        (setq eglot-events-buffer-size 0)
        :bind (:map eglot-mode-map
@@ -723,12 +731,6 @@
 
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package thrift)
-   #+END_SRC
-
-** Tree-sitter
-
-   #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package tree-sitter-langs)
    #+END_SRC
 
 ** Web


### PR DESCRIPTION
## Summary

- Remove `tree-sitter-langs` package (redundant with built-in tree-sitter in Emacs 29+)
- Move `gc-cons-threshold` and `read-process-output-max` to top-level (was buried in eglot `:config`)
- Increase `read-process-output-max` from 1MB to 4MB for faster LSP communication

## Why

1. **tree-sitter-langs**: You're already using built-in `-ts-mode` variants (go-ts-mode, tsx-ts-mode, etc.). The external package is redundant and slower.

2. **GC settings**: These were in eglot's `:config`, so they only took effect after eglot loaded. Now they apply immediately at startup.

## Verify native compilation

Run `M-: (native-comp-available-p)` - should return `t` for 2-5x speedup.

## Test plan

- [ ] Tangle and restart Emacs
- [ ] Open Go/TypeScript files, verify tree-sitter highlighting works
- [ ] Verify eglot connects normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)