### PR TITLE
Restore smex for M-x command history sorting

### DIFF
--- a/init.org
+++ b/init.org
@@ -379,7 +379,13 @@
        (ivy-mode 1))
    #+END_SRC
 
-   I mainly use projectile for fuzzy searching an entire project’s files and
+   Smex tracks M-x command usage and shows recently used commands first.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (use-package smex)
+   #+END_SRC
+
+   I mainly use projectile for fuzzy searching an entire project's files and
    buffers. It’s quite refreshing to never think about which files are open and
    which ones aren’t. The concept of a root directory is also important for
    things like ~rg~ searching.


### PR DESCRIPTION
## Summary
- Restores the smex package which was incorrectly removed in a previous cleanup PR
- Smex tracks M-x command usage and shows recently used commands first when using counsel-M-x

## Test plan
- [ ] Open Emacs and use M-x several times
- [ ] Verify that recently used commands appear at the top of the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)