### PR TITLE
Remove python-mode in favor of built-in python.el

### DIFF
--- a/init.org
+++ b/init.org
@@ -695,12 +695,6 @@
         (add-hook 'protobuf-mode-hook (lambda () (c-add-style "my-style" my-protobuf-style t))))
    #+END_SRC
 
-** Python
-
-   #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package python-mode)
-   #+END_SRC
-
 ** Ruby
 
    #+BEGIN_SRC emacs-lisp :tangle yes


### PR DESCRIPTION
## Summary
- Remove the python-mode package which was causing native-compiler warnings
- Emacs 30's built-in python.el and python-ts-mode provide equivalent functionality

The warnings were due to python-mode using deprecated `first`/`second` functions from cl and an old flymake API.

## Test plan
- [ ] Restart Emacs after tangling init.org
- [ ] Open a Python file and verify syntax highlighting and indentation work
- [ ] Verify no native-compiler warnings on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)