### PR TITLE
Fix Erlang config syntax and go-mode consistency

### DIFF
--- a/init.org
+++ b/init.org
@@ -546,8 +546,8 @@
          (lambda ()
            (setq mode-name "erl"
                  erlang-compile-extra-opts '((i . "../include"))
-                 erlang-root-dir "/usr/local/lib/erlang"))
-       (add-hook 'erlang-mode-hook #'eglot-ensure))
+                 erlang-root-dir "/usr/local/lib/erlang")))
+       (add-hook 'erlang-mode-hook #'eglot-ensure)
        ;; TODO Figure out how to turn this off for *.yrl files.
        (add-hook 'erlang-mode-hook 'erlfmt-on-save-mode))
    #+END_SRC
@@ -563,7 +563,7 @@
 
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package go-mode
-       :ensure t)
+       :defer t)
      (use-package go-ts-mode
        :custom
        (gofmt-show-errors nil)


### PR DESCRIPTION
## Summary

- Fix missing closing paren in `erlang-mode-hook` lambda that caused `eglot-ensure` to be incorrectly nested inside the lambda instead of being a separate hook
- Change `go-mode` from `:ensure t` to `:defer t` for consistency with straight.el package management

## Test plan

- [ ] Run `M-x org-babel-load-file` on init.org to regenerate init.el
- [ ] Verify Emacs starts without errors
- [ ] Open an Erlang file and confirm eglot starts correctly
- [ ] Open a Go file and confirm go-mode loads on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)