### PR TITLE
Add mood-line for a minimal, modern modeline

### DIFF
--- a/init.org
+++ b/init.org
@@ -141,6 +141,17 @@
        (plist-get base16-irblack-theme-colors id))
    #+END_SRC
 
+** Modeline
+
+   [[https://github.com/jessiehildebrandt/mood-line][mood-line]] provides a minimal, modern modeline.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (use-package mood-line
+       :config
+       (setq mood-line-glyph-alist mood-line-glyphs-unicode)
+       (mood-line-mode))
+   #+END_SRC
+
 ** Fonts and faces
 
    I use ~set-face-attribute~ for global faces instead of ~custom-set-faces~


### PR DESCRIPTION
## Summary

- Add mood-line package for a clean, minimal modeline
- Configure Unicode glyphs for visual indicators

## What mood-line displays

- Buffer name and modification status
- Major mode
- Line and column numbers
- Git branch (when in a repo)
- Flymake/eglot diagnostics

## Test plan

- [ ] Run `M-x org-babel-load-file` on init.org to regenerate init.el
- [ ] Verify Emacs starts without errors
- [ ] Confirm modeline shows Unicode glyphs and expected information

🤖 Generated with [Claude Code](https://claude.com/claude-code)