### PR TITLE
Fix modeline display and restore directory navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ auto-save-list/
 eln-cache/
 elpa/
 init.el
+history
 projectile-bookmarks.eld
 projectile.cache
 org-persist/

--- a/init.org
+++ b/init.org
@@ -147,9 +147,11 @@
 
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package mood-line
+       :demand t
+       :init
+       (mood-line-mode)
        :config
-       (setq mood-line-glyph-alist mood-line-glyphs-unicode)
-       (mood-line-mode))
+       (setq mood-line-glyph-alist mood-line-glyphs-unicode))
    #+END_SRC
 
 ** Fonts and faces
@@ -366,6 +368,17 @@
      (use-package vertico
        :init
        (vertico-mode))
+   #+END_SRC
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (use-package vertico-directory
+       :after vertico
+       :straight (:type built-in)
+       :bind (:map vertico-map
+              ("RET" . vertico-directory-enter)
+              ("DEL" . vertico-directory-delete-char)
+              ("M-DEL" . vertico-directory-delete-word))
+       :hook (rfn-eshadow-update-overlay . vertico-directory-tidy))
    #+END_SRC
 
    [[https://github.com/emacs-straight/savehist][Savehist]] persists minibuffer history across sessions, so frequently used


### PR DESCRIPTION
## Summary

- Fix mood-line not displaying by adding `:demand t` to force immediate loading
- Add vertico-directory extension to restore Ivy-like file navigation behavior:
  - `RET` enters directories instead of opening dired
  - `DEL` goes up one directory level
  - `~` resets to home directory
- Add `history` to .gitignore

## Test plan

- [ ] Run `M-x org-babel-load-file` on init.org to regenerate init.el
- [ ] Verify modeline shows buffer name, mode, line/column
- [ ] Test `C-x C-f` directory navigation with RET and ~

🤖 Generated with [Claude Code](https://claude.com/claude-code)