### PR TITLE
Switch from base16-theme to modus-vivendi

### DIFF
--- a/init.org
+++ b/init.org
@@ -131,14 +131,17 @@
 
 ** Theme
 
-   I've tried several themes, mostly within the base16 family.
+   Modus Vivendi is a dark theme with excellent contrast and readability,
+   built into Emacs 28+.
 
    #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package base16-theme
+     (use-package modus-themes
+       :straight (:type built-in)
        :init
-       (load-theme 'base16-irblack t))
-     (defun get-base16-color (id)
-       (plist-get base16-irblack-theme-colors id))
+       (load-theme 'modus-vivendi t))
+     (defun get-modus-color (name)
+       "Get a color from modus-vivendi theme."
+       (modus-themes-get-color-value name))
    #+END_SRC
 
 ** Fonts and faces
@@ -292,7 +295,7 @@
        :config
        (setq highlight-80+-columns 81)
        (set-face-attribute 'highlight-80+ nil :foreground 'unspecified
-                                              :background (get-base16-color ':base01)))
+                                              :background (get-modus-color 'bg-dim)))
    #+END_SRC
 
    I don't want to leave trailing whitespace in files. [[https://github.com/lewang/ws-butler][ws-butler only]] deletes
@@ -340,7 +343,7 @@
 
    #+BEGIN_SRC emacs-lisp :tangle yes
      (set-face-attribute 'show-paren-match nil :foreground 'unspecified
-                                               :background (get-base16-color ':base01))
+                                               :background (get-modus-color 'bg-paren-match))
      (setq show-paren-delay 0)
      (setq show-paren-style (quote expression))
      (show-paren-mode 1)


### PR DESCRIPTION
## Summary
- Replace base16-irblack with modus-vivendi, a built-in dark theme with excellent contrast and readability
- Rename `get-base16-color` to `get-modus-color` and update implementation to use `modus-themes-get-color-value`
- Update color references for highlight-80+ and show-paren-match faces

## Test plan
- [ ] Run `M-x org-babel-tangle` to regenerate init.el
- [ ] Restart Emacs and verify modus-vivendi theme loads correctly
- [ ] Check that 80+ column highlighting and paren matching use appropriate colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)