### PR TITLE
Remove Gleam mode configuration

### DIFF
--- a/init.org
+++ b/init.org
@@ -584,13 +584,6 @@
        (add-hook 'erlang-mode-hook 'erlfmt-on-save-mode))
    #+END_SRC
 
-** Gleam
-
-   #+BEGIN_SRC emacs-lisp :tangle yes
-     (use-package gleam-ts-mode
-       :mode (rx ".gleam" eos))
-   #+END_SRC
-
 ** [[https://github.com/dominikh/go-mode.el][Go]]
 
    #+BEGIN_SRC emacs-lisp :tangle yes


### PR DESCRIPTION
## Summary
- Remove gleam-ts-mode configuration from init.org

## Test plan
- [ ] Run `M-x org-babel-tangle` to regenerate init.el
- [ ] Restart Emacs and verify configuration loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)