### PR TITLE
Use json-ts-mode instead of web-mode for JSON files

### DIFF
--- a/init.org
+++ b/init.org
@@ -778,7 +778,7 @@
        (setq web-mode-enable-css-colorization t)
        (add-hook 'before-save-hook 'delete-trailing-whitespace nil 'local)
        :mode ("\\.html?\\'" "\\.erb\\'" "\\.hbs\\'"
-              "\\.json\\'" "\\.s?css\\'" "\\.less\\'" "\\.sass\\'"))
+              "\\.s?css\\'" "\\.less\\'" "\\.sass\\'"))
    #+END_SRC
 
 ** YAML


### PR DESCRIPTION
## Summary
- Remove `.json` from web-mode's file associations
- Allows treesit-auto to handle JSON files with `json-ts-mode` for proper tree-sitter syntax highlighting

## Test plan
- [ ] Open a JSON file in Emacs
- [ ] Verify the mode is `json-ts-mode` (check modeline)
- [ ] Confirm syntax highlighting is working
- [ ] If grammar is missing, run `M-x treesit-install-language-grammar RET json RET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)