### PR TITLE
Use swiper for C-s search with M-j word yanking

### DIFF
--- a/init.org
+++ b/init.org
@@ -404,13 +404,19 @@
 
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package consult
-       :bind (("C-s" . consult-line)
-              ("C-c f" . consult-find)
+       :bind (("C-c f" . consult-find)
               ("C-c k" . consult-ripgrep)
               ("C-x b" . consult-buffer))
        :config
        (setq consult-ripgrep-args
              "rg --null --line-buffered --color=never --max-columns=1000 --path-separator / --smart-case --no-heading --with-filename --line-number --search-zip"))
+   #+END_SRC
+
+   [[https://github.com/abo-abo/swiper][Swiper]] provides an interactive search with M-j to yank word at point.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (use-package swiper
+       :bind (("C-s" . swiper)))
    #+END_SRC
 
    [[https://github.com/oantolin/embark][Embark]] provides context actions on minibuffer candidates and other targets.


### PR DESCRIPTION
## Summary

- Replace `consult-line` with `swiper` for the `C-s` binding
- Swiper provides the familiar `M-j` keybinding to yank the word at point into the search minibuffer

## Test plan

- [ ] Run `M-x org-babel-tangle` to regenerate init.el
- [ ] Restart Emacs
- [ ] Press `C-s` to start swiper search
- [ ] Press `M-j` to yank word at point into search

🤖 Generated with [Claude Code](https://claude.com/claude-code)