### PR TITLE
Add coding conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,8 @@ Or evaluate: `(org-babel-tangle-file "init.org")`
 ## Package Management
 
 Packages are managed with straight.el and use-package. Run `M-x straight-pull-all` to update packages, then `M-x straight-freeze-versions` to lock versions.
+
+## Coding Conventions
+
+- Custom elisp functions should use the `jkakar/` prefix (e.g., `jkakar/minibuffer-yank-word`)
+- Never run `org-babel-tangle` automatically. Always ask the user to run it manually after making changes to `init.org`.


### PR DESCRIPTION
## Summary
- Add coding conventions section documenting the `jkakar/` prefix for custom elisp functions
- Document the requirement to ask users to run `org-babel-tangle` manually

## Test plan
- [x] Verify the markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)