### PR TITLE
Disable auto-completion and add spellchecking in markdown-mode

### DIFF
--- a/init.org
+++ b/init.org
@@ -6,7 +6,6 @@
 - Checkout https://github.com/alphapapa/bufler.el
 - Checkout https://www.reddit.com/r/emacs/comments/bb3nw7/connecting_workflows_with_aws_redshift/
 - Checkout https://xenodium.com/a-chatgpt-emacs-shell/
-- Spellchecking
 
 ** Tangling
 
@@ -692,7 +691,23 @@
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package markdown-mode
        :custom
-       (markdown-hide-urls t))
+       (markdown-hide-urls t)
+       :hook
+       (markdown-mode . (lambda () (setq-local corfu-auto nil))))
+   #+END_SRC
+
+** Spellchecking
+
+   Flyspell underlines misspelled words. Use ~M-$~ to check the word at point
+   with correction suggestions.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (use-package flyspell
+       :custom
+       (ispell-program-name "aspell")
+       :hook
+       (markdown-mode . flyspell-mode)
+       (flyspell-mode . flyspell-buffer))
    #+END_SRC
 
 ** Protocol buffers


### PR DESCRIPTION
## Summary

- Disable corfu auto-popup in markdown buffers to avoid disruptive autocomplete while writing prose (manual completion via `M-TAB` still works)
- Add flyspell with aspell for spellchecking in markdown files, scanning the full buffer on open
- Remove "Spellchecking" from the TODO list since it is now implemented

## Test plan

- [ ] Run `M-x org-babel-tangle` to regenerate `init.el`
- [ ] Open a `.md` file and confirm no autocomplete popup appears while typing
- [ ] Confirm `M-TAB` still triggers manual completion
- [ ] Misspell a word and confirm it gets underlined immediately
- [ ] Use `M-$` on a misspelled word and confirm correction suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)