### PR TITLE
Default directory follows most recent file buffer

### DIFF
--- a/init.org
+++ b/init.org
@@ -373,6 +373,22 @@
        (setq counsel-rg-base-command "rg -i -M 120 --no-heading --line-number --color never %s ."))
    #+END_SRC
 
+   When opening a file from a non-file buffer like =*scratch*=, default to the
+   directory of the most recently visited file buffer instead of =~/=.
+
+   #+BEGIN_SRC emacs-lisp :tangle yes
+     (defun jkakar/default-directory-from-last-file (&rest _)
+       "Set default-directory to the most recent file buffer's directory."
+       (unless (buffer-file-name)
+         (let ((dir (cl-loop for buf in (buffer-list)
+                             when (buffer-file-name buf)
+                             return (file-name-directory (buffer-file-name buf)))))
+           (when dir
+             (setq default-directory dir)))))
+
+     (advice-add 'counsel-find-file :before #'jkakar/default-directory-from-last-file)
+   #+END_SRC
+
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package ivy
        :init (setq ivy-use-virtual-buffers t


### PR DESCRIPTION
## Summary

- When `counsel-find-file` is called from a non-file buffer like `*scratch*`, the default directory is now set to the directory of the most recently visited file buffer instead of `~/`
- Uses `:before` advice on `counsel-find-file` that walks `buffer-list` to find the last file-visiting buffer
- No change to behavior when already in a file-visiting buffer

## Test plan

- [ ] Run `M-x org-babel-tangle` to regenerate `init.el`
- [ ] Restart Emacs
- [ ] Open a file in a project directory
- [ ] Switch to `*scratch*`
- [ ] Press `C-x C-f` — should start in the project directory, not `~/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)